### PR TITLE
Just drop them (CPython 3.5 and 3.6, that is)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
         python:
           - name: CPython 2.7
             action: '2.7'
-          - name: CPython 3.5
-            action: '3.5'
-          - name: CPython 3.6
-            action: '3.6'
           - name: CPython 3.7
             action: '3.7'
           - name: CPython 3.8

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Basic tests are run against various Python versions and operating systems.
    - macOS
    - Windows
 - Python
-   - CPython 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, and 3.10
+   - CPython 2.7, 3.7, 3.8, 3.9, and 3.10
    - PyPy 2, 3.7, and 3.8
 
 Sample Output


### PR DESCRIPTION
GitHub is raggedly allowing 3.5 and 3.6 support in Linux to drop from the `setup-python` action as they start using Ubuntu 22.04 instead of 20.04.  Both are EOL.

https://github.com/actions/setup-python/issues/544

replaces https://github.com/twisted/python-info-action/pull/18